### PR TITLE
Fork ember-url-hash-polyfill and remove 2-second delay for our use case

### DIFF
--- a/tests/integration/hash-test.ts
+++ b/tests/integration/hash-test.ts
@@ -6,7 +6,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 
-import { scrollToHash, uiSettled } from 'ember-url-hash-polyfill';
+import { scrollToHash } from 'ember-url-hash-polyfill';
 
 import { setupRouter } from './-helpers';
 
@@ -223,14 +223,12 @@ module('Hash', function (hooks) {
       debugAssert(`Expected all test elements to exist`, container);
 
       router.transitionTo('/foo');
-      await uiSettled(this.owner);
 
       assert.true(isVisible(find('#foo-first'), container), 'first header is visible');
       assert.false(isVisible(find('#foo-second'), container), 'second header is not visible');
       assert.equal(location.hash, '', 'initially, has no hash');
 
       router.transitionTo('/bar#bar-second');
-      await uiSettled(this.owner);
       await scrollSettled();
 
       assert.false(isVisible(find('#bar-first'), container), 'first header is not visible');
@@ -238,7 +236,6 @@ module('Hash', function (hooks) {
       assert.equal(location.hash, '#bar-second', 'clicked hash appears in URL');
 
       router.transitionTo('/foo#foo-second');
-      await uiSettled(this.owner);
       await scrollSettled();
 
       assert.false(isVisible(find('#foo-first'), container), 'first header is not visible');


### PR DESCRIPTION
See https://github.com/emporatitle/ember-url-hash-polyfill#ember-url-hash-polyfill for the rationale for `ember-url-hash-polyfill`'s existence.

For Empora, the lack of support in Ember for page anchors is preventing us from being able to route back to the action items section of the deal page after creating/updating an action item, and as we continue to build functionality in Ember, it'll be expected that this basic browser functionality will be supported.

I've been able to get the original `ember-url-hash-polyfill` working with Reggie, but it has a hardcoded delay while it waits for animation frames to finish, which means it takes 2 seconds to scroll down to the page anchor, at which point the user has probably already scrolled away to wherever they want to go.

Because we don't have a ton of animation in Reggie (and are unlikely to add much in the future), this delay can be removed for our use case.

As recently as August 2022, a member of the core Ember team said that they were working on first-class support for this problem (https://github.com/emberjs/rfcs/issues/709#issuecomment-1203193231), so hopefully this fork is temporary. If it proves not to be, I may PR a change to the original `ember-url-hash-polyfill` to make this configurable instead.